### PR TITLE
Windows fixes, improve getSha, minor refactor, update idr.

### DIFF
--- a/src/futurerestore.hpp
+++ b/src/futurerestore.hpp
@@ -18,6 +18,7 @@
 
 #include <cstdio>
 #include <functional>
+#include <utility>
 #include <vector>
 #include <array>
 #include <string>
@@ -115,13 +116,13 @@ class futurerestore {
 public:
     void test() const;
     struct idevicerestore_client_t* _client;
-    futurerestore(bool isUpdateInstall = false, bool isPwnDfu = false, bool noIBSS = false, bool setNonce = false, bool serial = false, bool noRestore = false, bool noRSEP = false);
+    explicit futurerestore(bool isUpdateInstall = false, bool isPwnDfu = false, bool noIBSS = false, bool setNonce = false, bool serial = false, bool noRestore = false, bool noRSEP = false);
     bool init();
-    int getDeviceMode(bool reRequest);
-    uint64_t getDeviceEcid();
+    int getDeviceMode(bool reRequest) const;
+    uint64_t getDeviceEcid() const;
     void putDeviceIntoRecovery();
-    void setAutoboot(bool val);
-    void exitRecovery();
+    void setAutoboot(bool val) const;
+    void exitRecovery() const;
     void waitForNonce();
     void waitForNonce(std::vector<const char *>nonces, size_t nonceSize);
     void loadAPTickets(const std::vector<const char *> &apticketPaths);
@@ -159,7 +160,7 @@ public:
     void loadRose(const std::string& rosePath) const;
     void loadSE(const std::string& sePath) const;
     void loadSavage(const std::array<std::string, 6>& savagePaths) const;
-    void loadVeridian(const std::string& veridianDGMPath, std::string veridianFWMPath) const;
+    void loadVeridian(const std::string& veridianDGMPath, const std::string& veridianFWMPath) const;
     void loadTimer(const std::string& timerPath) const;
     void loadBaobab(const std::string& baobabPath) const;
     void loadCryptex1(const std::string& cryptex1SysOSPath, const std::string& cryptex1SysVOLPath, const std::string& cryptex1SysTCPath, const std::string& cryptex1AppOSPath, const std::string& cryptex1AppVOLPath, const std::string& cryptex1AppTCPath) const;
@@ -170,30 +171,32 @@ public:
     static void loadBaseband(const std::string& basebandPath);
     static char *readBaseband(const std::string& basebandPath, char *data, size_t *sz);
     static unsigned char *getSHABuffer(char *data, size_t dataSize, int type = 0);
-    unsigned char *getSHA(const std::string& filePath, int type = 0);
+    static unsigned char *getSHABufferStream(std::ifstream &stream, int type = 0);
+    static size_t getFileSize(const std::string &name) ;
+    static unsigned char *getSHA(const std::string& filePath, int type = 0) ;
 
-    void setCustomLatest(std::string version){_customLatest = version; _useCustomLatest = true;}
-    void setCustomLatestBuildID(std::string version, bool beta, bool ota){_customLatestBuildID = version; _useCustomLatest = false; _useCustomLatestBuildID = true; _useCustomLatestBeta = beta; _useCustomLatestOTA = ota;}
-    void setSepPath(std::string sepPath) {_sepPath = sepPath;}
-    void setSepManifestPath(std::string sepManifestPath) {_sepManifestPath = sepManifestPath;}
-    void setRamdiskPath(std::string ramdiskPath) {_ramdiskPath = ramdiskPath;}
-    void setKernelPath(std::string kernelPath) {_kernelPath = kernelPath;}
-    void setBasebandPath(std::string basebandPath) {_basebandPath = basebandPath;}
-    void setBasebandManifestPath(std::string basebandManifestPath) {_basebandManifestPath = basebandManifestPath;}
+    void setCustomLatest(std::string version){_customLatest = std::move(version); _useCustomLatest = true;}
+    void setCustomLatestBuildID(std::string version, bool beta, bool ota){_customLatestBuildID = std::move(version); _useCustomLatest = false; _useCustomLatestBuildID = true; _useCustomLatestBeta = beta; _useCustomLatestOTA = ota;}
+    void setSepPath(std::string sepPath) {_sepPath = std::move(sepPath);}
+    void setSepManifestPath(std::string sepManifestPath) {_sepManifestPath = std::move(sepManifestPath);}
+    void setRamdiskPath(std::string ramdiskPath) {_ramdiskPath = std::move(ramdiskPath);}
+    void setKernelPath(std::string kernelPath) {_kernelPath = std::move(kernelPath);}
+    void setBasebandPath(std::string basebandPath) {_basebandPath = std::move(basebandPath);}
+    void setBasebandManifestPath(std::string basebandManifestPath) {_basebandManifestPath = std::move(basebandManifestPath);}
     void setNonce(const char *custom_nonce){_custom_nonce = custom_nonce;};
     void setBootArgs(const char *boot_args){_boot_args = boot_args;};
     void disableCache(){_noCache = true;};
     void skipBlobValidation(){_skipBlob = true;};
 
-    bool is32bit();
+    bool is32bit() const;
 
-    uint64_t getBasebandGoldCertIDFromDevice();
+    uint64_t getBasebandGoldCertIDFromDevice() const;
     
     void doRestore(const char *ipsw);
 
 #ifdef __APPLE__
     static int findProc(const char *procName, bool load);
-    void daemonManager(bool load);
+    static void daemonManager(bool load);
 #endif
 
     ~futurerestore();
@@ -202,7 +205,7 @@ public:
     static std::pair<const char *,size_t> getNonceFromSCAB(const char* scab, size_t scabSize);
     static uint64_t getEcidFromSCAB(const char* scab, size_t scabSize);
     static plist_t loadPlistFromFile(const char *path);
-    static void saveStringToFile(std::string str, std::string path);
+    static void saveStringToFile(std::string &str, std::string &path);
     static char *getPathOfElementInManifest(const char *element, const char *manifeststr, const char *boardConfig, int isUpdateInstall);
     static unsigned char *getDigestOfElementInManifest(const char *element, const char *manifeststr, const char *boardConfig, int isUpdateInstall);
     static unsigned char *getBBCFGDigestInManifest(const char *manifeststr, const char *boardConfig, int isUpdateInstall);


### PR DESCRIPTION
* For some reason msys2 makes stat use the 64bit struct but posix does not. This can cause the wrong data to be accessed.
* Instead of allocating each file into memory, get the SHA via chunks.
* Refactor code based on IDE warnings(clang tidy).
* Update idevicerestore to fix 3/7 year old bug for pwned custom restore mode kernel/ramdisk.